### PR TITLE
Change the repo name

### DIFF
--- a/include_pouet/footer.php
+++ b/include_pouet/footer.php
@@ -3,14 +3,14 @@
 <ul>
   <li><a href="//<?=(POUET_MOBILE ? POUET_WEB_HOSTNAME : POUET_MOBILE_HOSTNAME).$_SERVER["REQUEST_URI"]?>">switch to <?=(POUET_MOBILE ? "desktop" : "mobile")?> version</a></li>
   <li>
-    <a href="index.php">pouët.net</a> 2.0 &copy; 2000-<?=date("Y")?> <a href="groups.php?which=5">mandarine</a>
+    <a href="index.php">pouët.net</a> &copy; 2000-<?=date("Y")?> <a href="groups.php?which=5">mandarine</a>
     - hosted on <a href="http://www.scene.org/">scene.org</a>
     - follow us on <a href="https://twitter.com/pouetdotnet">twitter</a> and <a href="https://www.facebook.com/pouet.dot.net">facebook</a>
     - join us on <a href="https://discord.gg/MCDXrrB">discord</a> and <a href="https://webchat.ircnet.net/?channels=%23pouet.net&uio=OT10cnVlde">irc</a>
   </li>
   <li>
     send comments and bug reports to <a href="mailto:webmaster@pouet.net">webmaster@pouet.net</a>
-    or <a href="https://github.com/pouetnet/www.pouet.net">github</a>
+    or <a href="https://github.com/pouetnet/pouet-www">github</a>
   </li>
 <?php
 $timer["html"]["end"] = microtime_float();


### PR DESCRIPTION
This pull request includes updates to the `include_pouet/footer.php` file to correct links and remove outdated information. The most important changes are as follows:

* Removed the "2.0" version reference from the `pouët.net` link.
* Updated the GitHub repository link to the new URL `https://github.com/pouetnet/pouet-www`.