### PR TITLE
Delete google27abc0ca7eaf9151.html

### DIFF
--- a/google27abc0ca7eaf9151.html
+++ b/google27abc0ca7eaf9151.html
@@ -1,1 +1,0 @@
-google-site-verification: google27abc0ca7eaf9151.html


### PR DESCRIPTION
This pull request includes a small change to the `google27abc0ca7eaf9151.html` file. The change removes the Google site verification code from the file.

* [`google27abc0ca7eaf9151.html`](diffhunk://#diff-17ee899c4caae92e31525fd8ab59b37919180a82fcbc3b3174688310325320b2L1): Removed the Google site verification code.