### PR TITLE
content is a link to a folder, not a folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /cache/
-/content/
+/content
 /include_generic/credentials.inc.php
 
 # phpcs cache


### PR DESCRIPTION
Adding the trailing slash is only for actual folders