### PR TITLE
Add a comment to the `udlogin` column

### DIFF
--- a/pouet.sql
+++ b/pouet.sql
@@ -1118,7 +1118,7 @@ CREATE TABLE `users` (
   `level` enum('administrator','moderator','gloperator','user','pr0nstahr','fakeuser','banned') DEFAULT 'user',
   `avatar` varchar(255) NOT NULL,
   `registerDate` datetime DEFAULT NULL,
-  `udlogin` varchar(255) NOT NULL DEFAULT '',
+  `udlogin` varchar(255) NOT NULL DEFAULT '' COMMENT 'United Devices login, now dead.',
   `glops` int(10) unsigned NOT NULL DEFAULT 0,
   `thumbups` int(10) NOT NULL DEFAULT 0,
   `thumbdowns` int(10) NOT NULL DEFAULT 0,


### PR DESCRIPTION
This pull request makes a minor update to the `pouet.sql` database schema by adding a comment to clarify the purpose of the `udlogin` field in the `users` table.

* [`pouet.sql`](diffhunk://#diff-1e5b8e60205a0e356d86cb39bdf2845c97950f9a9e023ed07a53559303642878L1121-R1121): Added a comment to the `udlogin` column in the `users` table to indicate that it refers to a "United Devices login, now dead."