### PR TITLE
Don't redirect /gfx/lamer/

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -21,6 +21,7 @@ RewriteRule ^(.*)$ https://www.pouet.net/$1 [R=301,QSA,NE,L]
 # redirect all old directories to content domain
 
 RewriteRule ^avatars\/(.*)$ http://content.pouet.net/avatars/$1 [R=301,L]
+RewriteCond %{REQUEST_URI} !^/gfx/lamer/(.*)$
 RewriteRule ^gfx\/(.*)$ http://content.pouet.net/gfx/$1 [R=301,L]
 RewriteRule ^screenshots\/(.*)$ http://content.pouet.net/screenshots/$1 [R=301,L]
 


### PR DESCRIPTION
Attempt to fix https://github.com/pouetnet/pouet-www/pull/133#issuecomment-2883827681

Added a `RewriteCond` to prevent requests matching the pattern `^/gfx/lamer/(.*)` from being redirected. This ensures that such requests are excluded from the redirection applied to the `gfx` directory.